### PR TITLE
drop all utc conversion code

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -219,6 +219,9 @@ Version history
 
 * x.y (not yet released)
 
+  * no longer perform utc conversion, see
+    `temporenc#8 <https://github.com/temporenc/temporenc/issues/8>`_
+
 * 0.1
 
   Release date: 2014-10-30


### PR DESCRIPTION
no longer convert to utc when encoding (this is an upcoming temporenc
change). this also obsoletes the local=… arg to the conversion routines
that produce python datetime objects.